### PR TITLE
Feat: use vLLM & Self-Ask prompting

### DIFF
--- a/Full-Pipeline/pipeline.py
+++ b/Full-Pipeline/pipeline.py
@@ -149,13 +149,15 @@ def parse_args():
     retriever_group.add_argument("--embeddings", type=str, required=True, help="Document embedding path")
 
     query_generator_group = parser.add_argument_group("Query Generator Options")
-    query_generator_group.add_argument("--qg-tp-size", type=int, default=2, help="Tensor parallel size for query generator")
-    query_generator_group.add_argument("--qg-quantization", type=str, default="awq_marlin", help="Quantization method for query generator")
+    query_generator_group.add_argument("--qg-model-id", type=str, default="meta-llama/Llama-3.1-8B-instruct", help="Model ID for query generator")
+    query_generator_group.add_argument("--qg-tp-size", type=int, default=1, help="Tensor parallel size for query generator")
+    query_generator_group.add_argument("--qg-quantization", type=str, help="Quantization method for query generator")
     query_generator_group.add_argument("--qg-max-gen-length", type=int, default=512, help="Maximum generation length for query generator")
     query_generator_group.add_argument("--qg-temperature", type=float, default=0.7, help="Temperature for query generator")
     query_generator_group.add_argument("--qg-top-p", type=float, default=0.9, help="Top-p sampling for query generator")
 
     verifier_group = parser.add_argument_group("Verifier Options")
+    verifier_group.add_argument("--verifier-model-id", type=str, default="microsoft/DeBERTa-v3-large", help="Model ID for verifier")
     verifier_group.add_argument("--verifier-checkpoint-path", type=str, required=True, help="Checkpoint path for trained model")
     verifier_group.add_argument("--verifier-batch-size", type=int, default=8, help="Batch size for verifier")
     verifier_group.add_argument("--verifier-max-length", type=int, default=DEBERTA_MAX_LENGTH, help="Maximum length for verifier input")
@@ -186,7 +188,7 @@ def main(args: argparse.Namespace):
     )
 
     query_generator = QueryGenerator(
-        model_id="casperhansen/llama-3.3-70b-instruct-awq",
+        model_id=args.qg_model_id,
         tp_size=args.qg_tp_size,
         quantization=args.qg_quantization,
         max_gen_length=args.qg_max_gen_length,
@@ -195,7 +197,7 @@ def main(args: argparse.Namespace):
     )
 
     verifier = Verifier(
-        model_id="microsoft/DeBERTa-v3-large",
+        model_id=args.verifier_model_id,
         checkpoint_path=args.verifier_checkpoint_path,
         batch_size=args.verifier_batch_size,
         max_length=args.verifier_max_length,

--- a/Full-Pipeline/pipeline.py
+++ b/Full-Pipeline/pipeline.py
@@ -24,7 +24,7 @@ def print_results(em_list, precision_list, recall_list, f1_list):
     print("Total Recall", sum(recall_flat) / len(recall_flat) if recall_flat else 0)
     print("F1:", [sum(f1) / len(f1) if f1 else 0 for f1 in f1_list])
     print("Total F1", sum(f1_flat) / len(f1_flat) if f1_flat else 0)
-    print("\n")
+    print()
 
 
 def run_batch(retriever, query_generator, verifier, questions,
@@ -105,7 +105,7 @@ def run_batch(retriever, query_generator, verifier, questions,
             print("2. History:")
             for doc in history:
                 print(f"  Passage: {doc['text']}")
-            print("\n")
+            print()
 
     em_list = [[], [], []]
     precision_list = [[], [], []]

--- a/Full-Pipeline/pipeline.py
+++ b/Full-Pipeline/pipeline.py
@@ -56,8 +56,8 @@ def run_batch(retriever, query_generator, verifier, questions,
                     print(f"  Score: {score:.2f} | Passage: {doc['text']}")
                 print()
 
-        questions = []
-        batch_history = []
+        next_questions = []
+        next_batch_history = []
 
         for question, history, docs, scores in zip(questions, batch_history, batch_docs, batch_scores):
             for i, doc in enumerate(docs):
@@ -77,8 +77,11 @@ def run_batch(retriever, query_generator, verifier, questions,
                     "stop_iter": iter_count + 1
                 })
             else:
-                questions.append(question)
-                batch_history.append(history)
+                next_questions.append(question)
+                next_batch_history.append(history)
+
+        questions = next_questions
+        batch_history = next_batch_history
 
         print(f"Iteration {iter_count+1} completed in {time.time() - start_time:.2f} seconds")
         print(f"Remaining questions: {len(questions)}\n")
@@ -174,7 +177,7 @@ def parse_args():
     main_group.add_argument("--max-search", type=int, default=10, help="Maximum number of passages to retrieve")
     main_group.add_argument("--verifier-threshold", type=float, default=0.9, help="Threshold for verifier scores")
     main_group.add_argument("--log-trace", action="store_true", help="Log trace for debugging")
-    main_group.add_argument("--stop-log-path", type=str, default=None, help="Path to the JSONL file where stop logs are written (Optional)")
+    main_group.add_argument("--stop-log-path", type=str, default=None, help="Optional JSONL path; Path to the JSONL file where stopping logs are written")
 
     args = parser.parse_args()
     return args

--- a/Full-Pipeline/pipeline.py
+++ b/Full-Pipeline/pipeline.py
@@ -56,8 +56,8 @@ def run_batch(retriever, query_generator, verifier, questions,
                     print(f"  Score: {score:.2f} | Passage: {doc['text']}")
                 print()
 
-        next_questions = []
-        next_batch_history = []
+        questions = []
+        batch_history = []
 
         for question, history, docs, scores in zip(questions, batch_history, batch_docs, batch_scores):
             for i, doc in enumerate(docs):
@@ -77,11 +77,8 @@ def run_batch(retriever, query_generator, verifier, questions,
                     "stop_iter": iter_count + 1
                 })
             else:
-                next_questions.append(question)
-                next_batch_history.append(history)
-
-        questions = next_questions
-        batch_history = next_batch_history
+                questions.append(question)
+                batch_history.append(history)
 
         print(f"Iteration {iter_count+1} completed in {time.time() - start_time:.2f} seconds")
         print(f"Remaining questions: {len(questions)}\n")
@@ -177,7 +174,7 @@ def parse_args():
     main_group.add_argument("--max-search", type=int, default=10, help="Maximum number of passages to retrieve")
     main_group.add_argument("--verifier-threshold", type=float, default=0.9, help="Threshold for verifier scores")
     main_group.add_argument("--log-trace", action="store_true", help="Log trace for debugging")
-    main_group.add_argument("--stop-log-path", type=str, default=None, help="Optional JSONL path; Path to the JSONL file where stopping logs are written")
+    main_group.add_argument("--stop-log-path", type=str, default=None, help="Path to the JSONL file where stop logs are written (Optional)")
 
     args = parser.parse_args()
     return args
@@ -237,7 +234,7 @@ def main(args: argparse.Namespace):
             max_search=args.max_search,
             verifier_threshold=args.verifier_threshold,
             log_trace=args.log_trace,
-            stop_log_path=args.stop_log_path  
+            stop_log_path=args.stop_log_path,
         )
         for j in range(3):
             em_list[j].extend(em[j])

--- a/Full-Pipeline/pipeline_self_ask.py
+++ b/Full-Pipeline/pipeline_self_ask.py
@@ -1,0 +1,266 @@
+import os
+import time
+import json
+import argparse
+import wandb
+from config import WANDB_ENTITY, DEBERTA_MAX_LENGTH
+from .contriever import Retriever
+from .query_generator.query_generator_self_ask import QueryGenerator
+from .verifier import Verifier
+
+
+def print_results(em_list, precision_list, recall_list, f1_list):
+    em_flat = [item for sublist in em_list for item in sublist]
+    precision_flat = [item for sublist in precision_list for item in sublist]
+    recall_flat = [item for sublist in recall_list for item in sublist]
+    f1_flat = [item for sublist in f1_list for item in sublist]
+
+    print("Count:", [len(em) for em in em_list])
+    print("EM:", [sum(em) / len(em) if em else 0 for em in em_list])
+    print("Total EM", sum(em_flat) / len(em_flat) if em_flat else 0)
+    print("Precision:", [sum(precision) / len(precision) if precision else 0 for precision in precision_list])
+    print("Total Precision", sum(precision_flat) / len(precision_flat) if precision_flat else 0)
+    print("Recall:", [sum(recall) / len(recall) if recall else 0 for recall in recall_list])
+    print("Total Recall", sum(recall_flat) / len(recall_flat) if recall_flat else 0)
+    print("F1:", [sum(f1) / len(f1) if f1 else 0 for f1 in f1_list])
+    print("Total F1", sum(f1_flat) / len(f1_flat) if f1_flat else 0)
+    print("\n")
+
+
+def run_batch(retriever, query_generator, verifier, questions, max_iterations=5, max_search=10, verifier_threshold=0.9, log_trace=False):
+    final_questions = []
+    final_batch_history = []
+
+    batch_history = [[] for _ in range(len(questions))]
+    traces = ["Question: " + question["question"] + "\n" for question in questions]
+
+    iter_count = 0
+    while questions:
+        start_time = time.time()
+
+        next_questions = []
+        next_batch_history = []
+        next_traces = []
+        next_queries = []
+
+        traces, queries = query_generator.batch_generate(traces, is_first=iter_count==0)
+
+        for question, history, trace, query in zip(questions, batch_history, traces, queries):
+            if query:
+                next_questions.append(question)
+                next_batch_history.append(history)
+                next_traces.append(trace)
+                next_queries.append(query)
+            else:
+                final_questions.append(question)
+                final_batch_history.append(history)
+                if log_trace:
+                    print(f"1. Question: {question['question']}")
+                    print("2. Trace:")
+                    print(trace.strip())
+                    print("** Finished processing question. (QG) **")
+                    print("\n")
+
+        batch_docs = retriever.search(next_queries, max_search)
+        batch_scores = verifier.batch_verify(next_questions, next_batch_history, batch_docs)
+
+        questions = []
+        batch_history = []
+        traces = []
+
+        for question, history, trace, query, docs, scores in zip(next_questions, next_batch_history, next_traces, next_queries, batch_docs, batch_scores):
+            for i, doc in enumerate(docs):
+                if doc["id"] in {d["id"] for d in history}:
+                    scores[i] = -1
+            max_score = scores.max()
+            selected_doc = docs[scores.argmax()]
+            history.append(selected_doc)
+
+            if log_trace:
+                print(f"1. Question: {question['question']}")
+                print("2. Trace:")
+                print(trace.strip())
+                print(f"3. Generated query: {query}")
+                print("4. Retrieved passages and scores:")
+                for doc, score in zip(docs, scores):
+                    print(f"  Score: {score:.2f} | Passage: {doc['text']}")
+                if max_score >= verifier_threshold:
+                    print("** Finished processing question. (Verifier) **")
+                print("\n")
+
+            if max_score < verifier_threshold:
+                questions.append(question)
+                batch_history.append(history)
+                traces.append(trace + f"Context: {selected_doc['text']}\n")
+            else:
+                final_questions.append(question)
+                final_batch_history.append(history)
+
+        print("Iteration", iter_count + 1, "completed in", time.time() - start_time, "seconds")
+        print(f"Remaining questions: {len(questions)}\n")
+
+        iter_count += 1
+        if iter_count >= max_iterations:
+            final_questions.extend(questions)
+            final_batch_history.extend(batch_history)
+            break
+
+    if log_trace:
+        print("\nFinal Questions and History:\n")
+        for question, history in zip(final_questions, final_batch_history):
+            print(f"1. Question: {question['question']}")
+            print("2. History:")
+            for doc in history:
+                print(f"  Passage: {doc['text']}")
+            print("\n")
+
+    em_list = [[], [], []]
+    precision_list = [[], [], []]
+    recall_list = [[], [], []]
+    f1_list = [[], [], []]
+
+    # for question, history in zip(final_questions, final_batch_history):
+    #     question_id = question["id"]
+    #     correct = sum(int(question_id in doc["id"]) for doc in history)
+    #     num_hops = int(question_id[0])  # len(question["question_decomposition"])
+    #     num_retrieval = len(history)
+    #     em_list[num_hops - 2].append(int(correct == num_hops and num_hops == num_retrieval))
+    #     precision_list[num_hops - 2].append(correct / num_retrieval)
+    #     recall_list[num_hops - 2].append(correct / num_hops)
+    #     f1_list[num_hops - 2].append(2 * correct / (num_hops + num_retrieval))
+
+    for question, history in zip(final_questions, final_batch_history):
+        qid = question["id"]
+        decomposition = question.get("question_decomposition", [])
+        gold_idxs = [step["paragraph_support_idx"] for step in decomposition]
+        gold_chunk_ids = {f"{qid}-{idx:02d}" for idx in gold_idxs}
+        gold_hop = len(gold_chunk_ids)
+
+        correct = 0
+        for doc in history:
+            doc_chunks = set(doc["id"].split("//"))
+            if gold_chunk_ids & doc_chunks:
+                correct += 1
+
+        retrieved = len(history)
+        em = int(correct == gold_hop and retrieved == gold_hop)
+        precision = correct / retrieved if retrieved else 0.0
+        recall = correct / gold_hop   if gold_hop   else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+
+        ### FOR DEBUGGING ###
+        history_ids = [d["id"] for d in history]
+        print(f"[DEBUG] qid={qid}, gold_hop={gold_hop}, history_ids={history_ids}, "
+            f"correct={correct}, retrieved={retrieved}, em={em:.3f}, recall={recall:.3f}, precision={precision:.3f}")
+        #####################
+
+        idx = gold_hop - 2
+        em_list[idx].append(em)
+        precision_list[idx].append(precision)
+        recall_list[idx].append(recall)
+        f1_list[idx].append(f1)
+
+    return em_list, precision_list, recall_list, f1_list
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    retriever_group = parser.add_argument_group("Retriever Options")
+    retriever_group.add_argument("--passages", type=str, required=True, help="document file path")
+    retriever_group.add_argument("--embeddings", type=str, required=True, help="Document embedding path")
+
+    query_generator_group = parser.add_argument_group("Query Generator Options")
+    query_generator_group.add_argument("--qg-model-id", type=str, default="meta-llama/Llama-3.1-8B-instruct", help="Model ID for query generator")
+    query_generator_group.add_argument("--qg-tp-size", type=int, default=1, help="Tensor parallel size for query generator")
+    query_generator_group.add_argument("--qg-quantization", type=str, help="Quantization method for query generator")
+    query_generator_group.add_argument("--qg-max-gen-length", type=int, default=512, help="Maximum generation length for query generator")
+    query_generator_group.add_argument("--qg-temperature", type=float, default=0.7, help="Temperature for query generator")
+    query_generator_group.add_argument("--qg-top-p", type=float, default=0.9, help="Top-p sampling for query generator")
+
+    verifier_group = parser.add_argument_group("Verifier Options")
+    verifier_group.add_argument("--verifier-model-id", type=str, default="microsoft/DeBERTa-v3-large", help="Model ID for verifier")
+    verifier_group.add_argument("--verifier-checkpoint-path", type=str, required=True, help="Checkpoint path for trained model")
+    verifier_group.add_argument("--verifier-batch-size", type=int, default=8, help="Batch size for verifier")
+    verifier_group.add_argument("--verifier-max-length", type=int, default=DEBERTA_MAX_LENGTH, help="Maximum length for verifier input")
+
+    main_group = parser.add_argument_group("Main Options")
+    main_group.add_argument("--questions", type=str, required=True, help="Questions file path")
+    main_group.add_argument("--batch-size", type=int, default=32, help="Batch size for processing questions")
+    main_group.add_argument("--max-iterations", type=int, default=5, help="Maximum number of iterations")
+    main_group.add_argument("--max-search", type=int, default=10, help="Maximum number of passages to retrieve")
+    main_group.add_argument("--verifier-threshold", type=float, default=0.9, help="Threshold for verifier scores")
+    main_group.add_argument("--log-trace", action="store_true", help="Log trace for debugging")
+    args = parser.parse_args()
+    return args
+
+
+def main(args: argparse.Namespace):
+    local_rank = int(os.environ.get("LOCAL_RANK", -1))
+    if local_rank == -1 or local_rank == 0:  # Only initialize wandb on the main process
+        wandb.init(project="MultiHopQA-test", entity=WANDB_ENTITY)
+    else:
+        os.environ["WANDB_MODE"] = "disabled"  # Disable wandb for other processes
+
+    retriever = Retriever(
+        args.passages,
+        args.embeddings,
+        model_type="contriever",
+        model_path="facebook/contriever-msmarco",
+    )
+
+    query_generator = QueryGenerator(
+        model_id=args.qg_model_id,
+        tp_size=args.qg_tp_size,
+        quantization=args.qg_quantization,
+        max_gen_length=args.qg_max_gen_length,
+        temperature=args.qg_temperature,
+        top_p=args.qg_top_p,
+    )
+
+    verifier = Verifier(
+        model_id=args.verifier_model_id,
+        checkpoint_path=args.verifier_checkpoint_path,
+        batch_size=args.verifier_batch_size,
+        max_length=args.verifier_max_length,
+    )
+
+    with open(args.questions, "r", encoding="utf-8") as f:
+        questions = f.readlines()
+        questions = [json.loads(q) for q in questions]
+
+    em_list = [[], [], []]
+    precision_list = [[], [], []]
+    recall_list = [[], [], []]
+    f1_list = [[], [], []]
+
+    for i in range(0, len(questions), args.batch_size):
+        batch_questions = questions[i : i + args.batch_size]
+        print(f"Processing batch {i // args.batch_size + 1} of {len(questions) // args.batch_size + 1}...\n")
+        em, precision, recall, f1 = run_batch(
+            retriever=retriever,
+            query_generator=query_generator,
+            verifier=verifier,
+            questions=batch_questions,
+            max_iterations=args.max_iterations,
+            max_search=args.max_search,
+            verifier_threshold=args.verifier_threshold,
+            log_trace=args.log_trace,
+        )
+        for j in range(3):
+            em_list[j].extend(em[j])
+            precision_list[j].extend(precision[j])
+            recall_list[j].extend(recall[j])
+            f1_list[j].extend(f1[j])
+        print_results(em_list, precision_list, recall_list, f1_list)
+
+    print("Final Results:")
+    print_results(em_list, precision_list, recall_list, f1_list)
+    print("All done!")
+
+    wandb.finish()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/Full-Pipeline/pipeline_wo_verifier.py
+++ b/Full-Pipeline/pipeline_wo_verifier.py
@@ -53,8 +53,8 @@ def run_batch(retriever, query_generator, questions,
                     print(f"  Passage: {doc['text']}")
                 print()
 
-        next_questions = []
-        next_batch_history = []
+        questions = []
+        batch_history = []
 
         for question, history, query, docs in zip(questions, batch_history, queries, batch_docs):
             if query.strip().lower() == "<stop>":
@@ -72,11 +72,8 @@ def run_batch(retriever, query_generator, questions,
                     if cand["id"] not in existing_ids:
                         history.append(cand)
                         break
-                next_questions.append(question)
-                next_batch_history.append(history)
-
-        questions = next_questions
-        batch_history = next_batch_history
+                questions.append(question)
+                batch_history.append(history)
 
         print(f"Iteration {iter_count+1} completed in {time.time() - start_time:.2f} seconds")
         print(f"Remaining questions: {len(questions)}\n")
@@ -151,7 +148,7 @@ def parse_args():
     main_group.add_argument("--max-iterations", type=int, default=5, help="Maximum number of iterations")
     main_group.add_argument("--max-search", type=int, default=10, help="Maximum number of passages to retrieve")
     main_group.add_argument("--log-trace", action="store_true", help="Log trace for debugging")
-    main_group.add_argument("--stop-log-path", type=str, default=None, help="Optional JSONL path; Path to the JSONL file where stopping logs are written")
+    main_group.add_argument("--stop-log-path", type=str, default=None, help="Path to the JSONL file where stop logs are written (Optional)")
 
     return parser.parse_args()
 
@@ -200,7 +197,7 @@ def main(args: argparse.Namespace):
             max_iterations=args.max_iterations,
             max_search=args.max_search,
             log_trace=args.log_trace,
-            stop_log_path=args.stop_log_path
+            stop_log_path=args.stop_log_path,
         )
         for j in range(3):
             em_list[j].extend(em[j])

--- a/Full-Pipeline/query_generator/prompts.py
+++ b/Full-Pipeline/query_generator/prompts.py
@@ -40,7 +40,61 @@ Confirmed Passage 1: The Battle of Rich Mountain took place on July 11, 1861, in
 Confirmed Passage 2: Owing to its role in the state's history, the county motto is \"Where Illinois Began.\" It contains the historically important village of Kaskaskia, Illinois's first capital.
 Confirmed Passage 3: WIZE (1340 AM) — branded WIZE AM 1340 — is a commercial radio station in Springfield, Ohio owned by iHeartMedia, Inc. as part of their Dayton cluster. The station's main format is classic country targeted towards Springfield, and their transmitter - and former studios - are also located in Springfield.
 Your Response: From the given passages, I can see that the Battle of Rich Mountain occurred in Randolph County, Virginia (now West Virginia), and that Kaskaskia was Illinois's first capital. To answer the question, I need to know when Springfield became the capital of Illinois. Therefore, my retrieval query would be: <query>When did Springfield become the capital of Illinois?</query>
-<|eot_id|><|start_header_id|>user<|end_header_id|>
+<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
+Question: 
+"""
+
+COT_WO_VERIFIER_PROMPT = """
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+You are tasked with generating targeted retrieval queries for multi-hop questions. A multi-hop question requires multiple pieces of information to be answered fully.
+
+Given:
+- A multi-hop question
+- A set of confirmed, relevant passages (which may be empty)
+
+Your task:
+Generate a single retrieval query that targets ONE specific missing or complementary piece of evidence needed to answer the original question that is not covered by the provided passages.
+
+Guidelines:
+1. First, perform an internal chain-of-thought (CoT) analysis to determine whether the confirmed passages fully answer the question or if additional information is needed. (Do not include your CoT in the final output.)
+2. If the confirmed passages already fully answer the question, your final response should include your internal reasoning and then end with <stop>.
+3. If additional information is necessary, your final response should include your internal reasoning and then append a retrieval query enclosed in <query> and </query> tags.
+4. Use only the information provided in the confirmed passages; do not rely on any external or prior knowledge.
+
+[Information Sufficiency Checklist]
+- Do the confirmed passages contain all critical details (names, dates, events, locations, etc.) required to answer the question?
+- If all required details are present, your final response should end with <stop>.
+
+Few-Shot Examples:
+
+Example 1:
+Question: What is the capital of France?
+Your Response: The question asks for the capital of France, and the confirmed passage clearly states that the capital is Paris. All required details are provided. <stop>
+
+Example 2:
+Question: What's the meaning of the name of the school that does not include the Mahayava scriptures in its canon?
+Your Response: The question asks for the meaning of the school's name, but the confirmed passage does not provide the actual name of the school. I need the name to determine its meaning. <query>What is the name of the school that does not include the Mahayava scriptures in its canon?</query>
+
+Example 3:
+Question: Who was picked in the NBA draft before the player with the highest point average among active players?
+Confirmed Passage 1: "Wilt Chamberlain holds the all-time records for total points scored (4,029) and points per game (50.4) in a season; he also holds the rookie record when he averaged 37.6 points in the 1959–60 season. Among active players, Kevin Durant has the highest point average (32.0) in a season, achieved in the 2013–14 season."
+Your Response: The question seeks to know who was picked in the NBA draft before the player with the highest point average among active players. The confirmed passage shows that Kevin Durant is that player but does not specify who was drafted before him. <query>Who was picked in the NBA draft before Kevin Durant?</query>
+
+Example 4:
+Question: When did the city that WIZE is licensed to broadcast to become the capital of the state that contains the county where the Battle of Rich Mountain occurred?
+Confirmed Passage 1: "The Battle of Rich Mountain took place on July 11, 1861, in Randolph County, Virginia (now West Virginia) during the American Civil War."
+Confirmed Passage 2: "Kaskaskia, located in that county, was Illinois's first capital."
+Confirmed Passage 3: "WIZE (1340 AM) is a radio station based in Springfield, Ohio."
+Your Response: The confirmed passages provide historical context and indicate that Kaskaskia was Illinois's first capital, but they do not specify when Springfield became the capital of Illinois. <query>When did Springfield become the capital of Illinois?</query>
+
+Example 5 (2-Hop with Two Confirmed Passages – <stop> Output):
+Question: What river flows through Paris, and which iconic monument on its banks was completed in 1889?
+Confirmed Passage 1: "The Seine River flows through the heart of Paris."
+Confirmed Passage 2: "The Eiffel Tower, an iconic monument along the Seine, was completed in 1889."
+Your Response: The question asks for the river flowing through Paris and the iconic monument completed in 1889 on its banks. The confirmed passages provide both details: the Seine River and the Eiffel Tower. All required information is present. <stop>
+<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
 Question: 
 """
 
@@ -88,5 +142,6 @@ Follow up: When did hurricane sandy hit New York City?
 Context: Effects of Hurricane Sandy in New York: Hurricane Sandy Category 1 hurricane (SSHWS / NWS) Satellite image of Sandy at 4: 15 p.m. EDT on October 29 as it was about to make landfall on the Jersey Shore Formed October 28, 2012 (First rainbands begin to affect New Jersey) Dissipated November 2, 2012 (Dissipated as extratropical cyclone) (Extratropical after October 29) Highest winds 1 - minute sustained: 80 mph (130 km / h) Highest gust Gusts: 100 mph (155 km / h) Lowest pressure 945 mbar (hPa); 27.91 inHg Fatalities 53 total Damage $32 billion (2012 USD) (Estimated damage total) Areas affected New York, especially the New York metropolitan area Part of the 2012 Atlantic hurricane season Part of a series on Hurricane Sandy General Meteorological history Impact Greater Antilles United States Maryland and Washington, D.C. New Jersey New York New England Canada Other wikis Commons: Sandy images Wikinews: Sandy stories
 Intermediate answer: Hurricane sandy hit New York City in October 28, 2012.
 So the final answer is: October 28, 2012
-<|eot_id|><|start_header_id|>user<|end_header_id|>
+<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
 """

--- a/Full-Pipeline/query_generator/prompts.py
+++ b/Full-Pipeline/query_generator/prompts.py
@@ -1,0 +1,92 @@
+COT_PROMPT = """
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+You are tasked with generating targeted retrieval queries for multi-hop questions. A multi-hop question requires multiple pieces of information to be answered fully.
+
+Given:
+- A multi-hop question
+- A set of already confirmed relevant passages (which may be empty)
+
+Your task:
+Generate a single retrieval query that targets ONE specific piece of missing or complementary evidence needed to answer the original question but not covered in the provided passages.
+
+Guidelines:
+- Create a single-hop question (answerable by referring to a single piece of information)
+- Be specific enough to retrieve relevant information but not overly restrictive
+- Maintain important entities and keywords from the original question
+- Focus on the most critical missing information
+- If multiple pieces of information are missing, prioritize the most fundamental one
+- DO NOT use any prior knowledge beyond the provided passages.
+
+You may add some additional explanation or commentary in your response, but make sure to wrap the final retrieval query between <query> and </query> tags.
+
+Here are some examples for your reference:
+
+Example 1:
+Question: What's the meaning of the name of the school that does not include the Mahayava scriptures in its canon?
+Your Response: The given question is asking about the meaning of the name of a specific school. To answer this, I need to know the name of the school that does not include the Mahayava scriptures in its canon. Therefore, my retrieval query would be: <query>What is the name of the school that does not include the Mahayava scriptures in its canon?</query>
+
+Example 2:
+Question: Who founded the company that distributed the film UHF?
+Your Response: The given question is asking about the founder of a specific company. To answer this, I need to know the name of the company that distributed the film UHF. Therefore, my retrieval query would be: <query>What is the name of the company that distributed the film UHF?</query>
+
+Example 3:
+Question: Who was picked in the NBA draft before the player with the highest point average among active players?
+Confirmed Passage 1: Wilt Chamberlain holds the all - time records for total points scored (4,029) and points per game (50.4) in a season; both records were achieved in the 1961 -- 62 season. He also holds the rookie records for points per game when he averaged 37.6 points in the 1959 -- 60 season. Among active players, Kevin Durant has the highest point total (2,593) and the highest scoring average (32.0) in a season; both were achieved in the 2013 -- 14 season.
+Your Response: From the given passage, I can see that Kevin Durant has the highest point average among active players. To answer the question, I need to know who was picked in the NBA draft before him. Therefore, my retrieval query would be: <query>Who was picked in the NBA draft before Kevin Durant?</query>
+
+Example 4:
+Question: When did the city that WIZE is licensed to broadcast to, become the capital of the state, that contains the county where the Battle of Rich Mountain occurred?
+Confirmed Passage 1: The Battle of Rich Mountain took place on July 11, 1861, in Randolph County, Virginia (now West Virginia) as part of the Operations in Western Virginia Campaign during the American Civil War.
+Confirmed Passage 2: Owing to its role in the state's history, the county motto is \"Where Illinois Began.\" It contains the historically important village of Kaskaskia, Illinois's first capital.
+Confirmed Passage 3: WIZE (1340 AM) — branded WIZE AM 1340 — is a commercial radio station in Springfield, Ohio owned by iHeartMedia, Inc. as part of their Dayton cluster. The station's main format is classic country targeted towards Springfield, and their transmitter - and former studios - are also located in Springfield.
+Your Response: From the given passages, I can see that the Battle of Rich Mountain occurred in Randolph County, Virginia (now West Virginia), and that Kaskaskia was Illinois's first capital. To answer the question, I need to know when Springfield became the capital of Illinois. Therefore, my retrieval query would be: <query>When did Springfield become the capital of Illinois?</query>
+<|eot_id|><|start_header_id|>user<|end_header_id|>
+Question: 
+"""
+
+SELF_ASK_PROMPT = """
+<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+Given the following question, answer it by providing follow up questions and intermediate answers.
+For each follow up question, you are given a context which is the top returned Wikipedia snippet for the question.
+First give an intermediate answer to the follow up question. Start the line with "Intermediate answer: ".
+Then, ask a next follow up question if necessary. Start the line with "Follow up: ".
+If no follow up questions are necessary, give a final answer directly. Start the line with "So the final answer is: ".
+Output only the process after the given prompt. Do not repeat the given prompt in your response.
+
+#
+Question: What is the major railroad museum located in the location where Andre Bloc lived at his time of death?
+Follow up: Where did André Bloc live when he died?
+Context: André Bloc (Algiers, May 23, 1896 – New Delhi, November 8, 1966) was a French sculptor, magazine editor, and founder of several specialist journals. He founded the "Groupe Espace" in 1949.
+Intermediate answer: André Bloc was living in New Delhi when he died.
+Follow up: What is the name of the major railroad related museum located in New Delhi?
+Context: New Delhi is home to Indira Gandhi Memorial Museum, National Gallery of Modern Art, National Museum of Natural History, National Rail Museum, National Handicrafts and Handlooms Museum, National Philatelic Museum, Nehru Planetarium, Shankar's International Dolls Museum. and Supreme Court of India Museum.
+Intermediate answer: The National Rail Museum is located in New Delhi.
+So the final answer is: National Rail Museum
+
+#
+Question: What is the least popular official language in the country where a spiral viaduct is located in Karin Thomas' birthplace?
+Follow up: Where was Karin Thomas born?
+Context: Karin Thomas (born 3 October 1961 in Brusio) was a Swiss cross country skier who competed from 1982 to 1988. She finished sixth in the 4 x 5 km relay at the 1984 Winter Olympics in Sarajevo and fourth in that same event at the 1988 Winter Olympics in Calgary.
+Intermediate answer: Karin Thomas was born in Brusio.
+Follow up: In which country is a spiral viaduct is located in Brusio?
+Context: Brusio spiral viaduct: A signature structure of the World Heritage-listed Bernina railway, it is located near Brusio, in the Canton of Graubünden, Switzerland, and was built to limit the railway's gradient at that location within its specified maximum of 7%.
+Intermediate answer: The Brusio spiral viaduct is located in Switzerland.
+Follow up: What is the least popular official language of Switzerland?
+Context: Switzerland has four official languages: principally German (63.5% total population share, with foreign residents, in 2013); French (22.5%) in the west; and Italian (8.1%) in the south. The fourth official language, Romansh (0.5%), is a Romance language spoken locally in the southeastern trilingual canton of Graubünden, and is designated by Article 4 of the Federal Constitution as a national language along with German, French, and Italian, and in Article 70 as an official language if the authorities communicate with persons who speak Romansh. However, federal laws and other official acts do not need to be decreed in Romansh.
+Intermediate answer: The least popular official language is Romansh.
+So the final answer is: Romansh
+
+#
+Question: When did hurricane Sandy his the city where The Dealers' performer was born?
+Follow up: Who is the performer of The Dealers?
+Context: The Dealers is a 1964 album by jazz musician Mal Waldron released on Status Records, catalogue 8316. The album consists of unreleased takes from two sessions that resulted in two prior albums. "Blue Calypso" and "Falling In Love With Love" are from the April 19, 1957 session that resulted in half of 1957 Waldron's "Mal/2" album; these tracks can currently be found as additional tracks on the CD reissue of that album. "Dealin'" and "Wheelin" are from a September 20, 1957 session, and are alternate takes of tracks originally released on the 1958 "Wheelin' & Dealin'" album (Prestige PRLP 7131); these tracks can currently be found as additional tracks on the CD reissue of that album. All tracks are also available as part of the 2009 John Coltrane's box set "Side Steps".
+Intermediate answer: The Dealers is an album by Mal Waldron.
+Follow up: Where was Mal Waldron born?
+Context: Malcolm Earl "Mal" Waldron (August 16, 1925 – December 2, 2002) was an American jazz pianist, composer, and arranger. Mal Waldron was born in New York City on August 16, 1925, to West Indian immigrants. His father was a mechanical engineer who worked on the Long Island Rail Road. The family moved to Jamaica, Queens when Mal was four years old. Waldron's parents discouraged his initial interest in jazz, but he was able to maintain it by listening to swing on the radio.
+Intermediate answer: Mal Waldron was born in New York City.
+Follow up: When did hurricane sandy hit New York City?
+Context: Effects of Hurricane Sandy in New York: Hurricane Sandy Category 1 hurricane (SSHWS / NWS) Satellite image of Sandy at 4: 15 p.m. EDT on October 29 as it was about to make landfall on the Jersey Shore Formed October 28, 2012 (First rainbands begin to affect New Jersey) Dissipated November 2, 2012 (Dissipated as extratropical cyclone) (Extratropical after October 29) Highest winds 1 - minute sustained: 80 mph (130 km / h) Highest gust Gusts: 100 mph (155 km / h) Lowest pressure 945 mbar (hPa); 27.91 inHg Fatalities 53 total Damage $32 billion (2012 USD) (Estimated damage total) Areas affected New York, especially the New York metropolitan area Part of the 2012 Atlantic hurricane season Part of a series on Hurricane Sandy General Meteorological history Impact Greater Antilles United States Maryland and Washington, D.C. New Jersey New York New England Canada Other wikis Commons: Sandy images Wikinews: Sandy stories
+Intermediate answer: Hurricane sandy hit New York City in October 28, 2012.
+So the final answer is: October 28, 2012
+<|eot_id|><|start_header_id|>user<|end_header_id|>
+"""

--- a/Full-Pipeline/query_generator/query_generator.py
+++ b/Full-Pipeline/query_generator/query_generator.py
@@ -1,69 +1,31 @@
+import os
 import re
-import json
 import torch
-import argparse
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from vllm import LLM, SamplingParams
+from .prompts import COT_PROMPT
 
 
 class QueryGenerator:
-    def __init__(self, model_id, cache_dir=None, max_gen_length=200, temperature=0.7, top_p=0.9):
-        self.max_gen_length = max_gen_length
-        self.temperature = temperature
-        self.top_p = top_p
+    def __init__(self, model_id, tp_size, quantization, max_gen_length=200, temperature=0.7, top_p=0.9):
+        os.environ['MKL_THREADING_LAYER']='GNU'
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_id, 
-            cache_dir=cache_dir, 
+        self.llm = LLM(
+            model=model_id,
+            tensor_parallel_size=tp_size,
+            quantization=quantization,
+            dtype=torch.bfloat16,
+            gpu_memory_utilization=0.9,
             trust_remote_code=True,
         )
-        if self.tokenizer.pad_token is None:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            cache_dir=cache_dir,
-            torch_dtype=torch.bfloat16,
-            trust_remote_code=True,
-            device_map="auto",
+
+        self.sampling_params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_gen_length,
         )
 
     def _gen_retriever_query_prompt(self, question, confirmed_passages):
-        prompt = (
-            "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
-            "You are tasked with generating targeted retrieval queries for multi-hop questions. A multi-hop question requires multiple pieces of information to be answered fully.\n\n"
-            "Given:\n"
-            "- A multi-hop question\n"
-            "- A set of already confirmed relevant passages (which may be empty)\n\n"
-            "Your task:\n"
-            "Generate a single retrieval query that targets ONE specific piece of missing or complementary evidence needed to answer the original question but not covered in the provided passages.\n\n"
-            "Guidelines:\n"
-            "- Create a single-hop question (answerable by referring to a single piece of information)\n"
-            "- Be specific enough to retrieve relevant information but not overly restrictive\n"
-            "- Maintain important entities and keywords from the original question\n"
-            "- Focus on the most critical missing information\n"
-            "- If multiple pieces of information are missing, prioritize the most fundamental one\n"
-            "- DO NOT use any prior knowledge beyond the provided passages.\n\n"
-            "You may add some additional explanation or commentary in your response, but make sure to wrap the final retrieval query between <query> and </query> tags.\n\n"
-            "Here are some examples for your reference:\n\n"
-            "Example 1:\n"
-            "Question: What's the meaning of the name of the school that does not include the Mahayava scriptures in its canon?\n"
-            "Your Response: The given question is asking about the meaning of the name of a specific school. To answer this, I need to know the name of the school that does not include the Mahayava scriptures in its canon. Therefore, my retrieval query would be: <query>What is the name of the school that does not include the Mahayava scriptures in its canon?</query>\n\n"
-            "Example 2:\n"
-            "Question: Who founded the company that distributed the film UHF?\n"
-            "Your Response: The given question is asking about the founder of a specific company. To answer this, I need to know the name of the company that distributed the film UHF. Therefore, my retrieval query would be: <query>What is the name of the company that distributed the film UHF?</query>\n\n"
-            "Example 3:\n"
-            "Question: Who was picked in the NBA draft before the player with the highest point average among active players?\n"
-            "Confirmed Passage 1: Wilt Chamberlain holds the all - time records for total points scored (4,029) and points per game (50.4) in a season; both records were achieved in the 1961 -- 62 season. He also holds the rookie records for points per game when he averaged 37.6 points in the 1959 -- 60 season. Among active players, Kevin Durant has the highest point total (2,593) and the highest scoring average (32.0) in a season; both were achieved in the 2013 -- 14 season.\n"
-            "Your Response: From the given passage, I can see that Kevin Durant has the highest point average among active players. To answer the question, I need to know who was picked in the NBA draft before him. Therefore, my retrieval query would be: <query>Who was picked in the NBA draft before Kevin Durant?</query>\n\n"
-            "Example 4:\n"
-            "Question: When did the city that WIZE is licensed to broadcast to, become the capital of the state, that contains the county where the Battle of Rich Mountain occurred?\n"
-            "Confirmed Passage 1: The Battle of Rich Mountain took place on July 11, 1861, in Randolph County, Virginia (now West Virginia) as part of the Operations in Western Virginia Campaign during the American Civil War.\n"
-            "Confirmed Passage 2: Owing to its role in the state's history, the county motto is \"Where Illinois Began.\" It contains the historically important village of Kaskaskia, Illinois's first capital.\n"
-            "Confirmed Passage 3: WIZE (1340 AM) — branded WIZE AM 1340 — is a commercial radio station in Springfield, Ohio owned by iHeartMedia, Inc. as part of their Dayton cluster. The station's main format is classic country targeted towards Springfield, and their transmitter - and former studios - are also located in Springfield.\n"
-            "Your Response: From the given passages, I can see that the Battle of Rich Mountain occurred in Randolph County, Virginia (now West Virginia), and that Kaskaskia was Illinois's first capital. To answer the question, I need to know when Springfield became the capital of Illinois. Therefore, my retrieval query would be: <query>When did Springfield become the capital of Illinois?</query>\n"
-            "<|eot_id|>\n"
-            "<|start_header_id|>user<|end_header_id|>\n"
-            f"Question: {question}\n"
-        )
+        prompt = COT_PROMPT + question + "\n"
         if confirmed_passages:
             for idx, passage in enumerate(confirmed_passages, start=1):
                 prompt += f"Confirmed Passage {idx}: {passage['text']}\n"
@@ -75,20 +37,10 @@ class QueryGenerator:
             self._gen_retriever_query_prompt(question["question"], confirmed_passages)
             for question, confirmed_passages in zip(questions, batch_confirmed_passages)
         ]
-        inputs = self.tokenizer(prompts, padding=True, padding_side="left", return_tensors="pt").to(self.model.device)
 
-        input_lengths = [i.size(0) for i in inputs["input_ids"]]
-        outputs = self.model.generate(
-            **inputs,
-            max_new_tokens=self.max_gen_length,
-            temperature=self.temperature,
-            top_p=self.top_p,
-        )
-        generated_texts = self.tokenizer.batch_decode(
-            [output[input_lengths[i]:] for i, output in enumerate(outputs)],
-            skip_special_tokens=True,
-        )
-        clean_texts = [self.extract_query(text) for text in generated_texts]
+        outputs = self.llm.generate(prompts, self.sampling_params)
+
+        clean_texts = [self.extract_query(output.outputs[0].text) for output in outputs]
         return clean_texts
 
     def extract_query(self, generated_text):
@@ -101,18 +53,12 @@ class QueryGenerator:
             return generated_text.strip()
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--cache-dir", type=str, help="Cache directory for model")
-    args = parser.parse_args()
-    return args
-
-
-def test(args: argparse.Namespace):
+def test():
     query_generator = QueryGenerator(
-        model_id="meta-llama/Meta-Llama-3-8B-Instruct",
-        cache_dir=args.cache_dir,
-        max_gen_length=200,
+        model_id="casperhansen/llama-3.3-70b-instruct-awq",
+        tp_size=2,
+        quantization="awq_marlin",
+        max_gen_length=2048,
         temperature=0.7,
         top_p=0.9,
     )
@@ -134,5 +80,4 @@ def test(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    test(args)
+    test()

--- a/Full-Pipeline/query_generator/query_generator_self_ask.py
+++ b/Full-Pipeline/query_generator/query_generator_self_ask.py
@@ -1,0 +1,96 @@
+import os
+import torch
+from vllm import LLM, SamplingParams
+from .prompts import SELF_ASK_PROMPT
+
+
+class QueryGenerator:
+    def __init__(self, model_id, tp_size, quantization, max_gen_length=200, temperature=0.7, top_p=0.9):
+        os.environ['MKL_THREADING_LAYER']='GNU'
+
+        self.llm = LLM(
+            model=model_id,
+            tensor_parallel_size=tp_size,
+            quantization=quantization,
+            gpu_memory_utilization=0.9,
+            dtype=torch.bfloat16,
+            trust_remote_code=True,
+        )
+
+        self.sampling_params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_gen_length,
+        )
+
+        print("Model loaded successfully.")
+
+    def _gen_retriever_query_prompt(self, trace, is_first=False):
+        prompt = SELF_ASK_PROMPT + "\n" + trace
+        if is_first:
+            prompt += "Give a follow up question.<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+        else:
+            prompt += (
+                "Give an intermediate answer and a follow up question if needed. If not, give the final answer."
+                "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n"
+            )
+        return prompt.strip()
+
+    def batch_generate(self, traces, is_first=False):
+        prompts = [self._gen_retriever_query_prompt(trace, is_first) for trace in traces]
+
+        outputs = self.llm.generate(prompts, self.sampling_params)
+
+        new_traces = []
+        queries = []
+        for trace, output in zip(traces, outputs):
+            new_trace, query = self.extract_query(output.outputs[0].text)
+            trace += new_trace
+            if query:
+                new_traces.append(trace)
+                queries.append(query)
+            else:
+                new_traces.append(trace)
+                queries.append("")
+
+        return new_traces, queries
+
+    def extract_query(self, text):
+        lines = text.strip().split('\n')
+        trace = ""
+        for line in lines:
+            trace += line.strip() + "\n"
+            if line.strip().lower().startswith("follow up: ") or line.strip().lower().startswith("follow-up: "):
+                return trace, line.strip()[len("Follow up: "):]
+        return trace, None
+
+
+def test():
+    query_generator = QueryGenerator(
+        model_id="casperhansen/llama-3.3-70b-instruct-awq",
+        tp_size=2,
+        quantization="awq_marlin",
+        max_gen_length=2048,
+        temperature=0.7,
+        top_p=0.9,
+    )
+
+    traces = [(
+        "Question: Country A has an embassy from the country that produces the show Krystala. Who was a prominent figure in the radio division of the network that created a version of the Biggest Loser for country A?\n"
+        "Are follow up questions needed here: Yes.\n"
+        "Follow up: Which country produces the show Krystala?\n"
+        "Context: Krystala is a daily fantasy/sci-fi/adventure/soap opera serial (superserye/fantaserye) from the Philippines, where it was produced by and aired on ABS-CBN from October 11, 2004 to April 22, 2005. The show also aired simultaneously on The Filipino Channel and on a one-week delay on International Channel (now AZN-TV) in the United States.\n"
+    )]
+    is_first = False
+
+    new_traces, queries = query_generator.batch_generate(traces, is_first)
+    for trace, query in zip(new_traces, queries):
+        print("Trace: ")
+        print(trace)
+        print(f"Query: {query}")
+        print("-" * 50)
+    print("Test completed.")
+
+
+if __name__ == "__main__":
+    test()

--- a/Full-Pipeline/query_generator/query_generator_wo_verifier.py
+++ b/Full-Pipeline/query_generator/query_generator_wo_verifier.py
@@ -1,74 +1,31 @@
+import os
 import re
-import json
 import torch
-import argparse
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from vllm import LLM, SamplingParams
+from .prompts import COT_WO_VERIFIER_PROMPT
 
 
 class QueryGenerator:
-    def __init__(self, model_id, cache_dir=None, max_gen_length=200, temperature=0.7, top_p=0.9):
-        self.max_gen_length = max_gen_length
-        self.temperature = temperature
-        self.top_p = top_p
+    def __init__(self, model_id, tp_size, quantization, max_gen_length=200, temperature=0.7, top_p=0.9):
+        os.environ['MKL_THREADING_LAYER']='GNU'
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            model_id, 
-            cache_dir=cache_dir, 
+        self.llm = LLM(
+            model=model_id,
+            tensor_parallel_size=tp_size,
+            quantization=quantization,
+            dtype=torch.bfloat16,
+            gpu_memory_utilization=0.9,
             trust_remote_code=True,
         )
-        if self.tokenizer.pad_token is None:
-            self.tokenizer.pad_token = self.tokenizer.eos_token
-        self.model = AutoModelForCausalLM.from_pretrained(
-            model_id,
-            cache_dir=cache_dir,
-            torch_dtype=torch.bfloat16,
-            trust_remote_code=True,
-            device_map="auto",
+
+        self.sampling_params = SamplingParams(
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_gen_length,
         )
 
     def _gen_retriever_query_prompt(self, question, confirmed_passages):
-        prompt = (
-            "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n"
-            "You are tasked with generating targeted retrieval queries for multi-hop questions. A multi-hop question requires multiple pieces of information to be answered fully.\n\n"
-            "Given:\n"
-            "- A multi-hop question\n"
-            "- A set of confirmed, relevant passages (which may be empty)\n\n"
-            "Your task:\n"
-            "Generate a single retrieval query that targets ONE specific missing or complementary piece of evidence needed to answer the original question that is not covered by the provided passages.\n\n"
-            "Guidelines:\n"
-            "1. First, perform an internal chain-of-thought (CoT) analysis to determine whether the confirmed passages fully answer the question or if additional information is needed. (Do not include your CoT in the final output.)\n"
-            "2. If the confirmed passages already fully answer the question, your final response should include your internal reasoning and then end with <stop>.\n"
-            "3. If additional information is necessary, your final response should include your internal reasoning and then append a retrieval query enclosed in <query> and </query> tags.\n"
-            "4. Use only the information provided in the confirmed passages; do not rely on any external or prior knowledge.\n\n"
-            "[Information Sufficiency Checklist]\n"
-            "- Do the confirmed passages contain all critical details (names, dates, events, locations, etc.) required to answer the question?\n"
-            "- If all required details are present, your final response should end with <stop>.\n\n"
-            "Few-Shot Examples:\n\n"
-            "Example 1:\n"
-            "Question: What is the capital of France?\n"
-            "Your Response: The question asks for the capital of France, and the confirmed passage clearly states that the capital is Paris. All required details are provided. <stop>\n\n"
-            "Example 2:\n"
-            "Question: What's the meaning of the name of the school that does not include the Mahayava scriptures in its canon?\n"
-            "Your Response: The question asks for the meaning of the school's name, but the confirmed passage does not provide the actual name of the school. I need the name to determine its meaning. <query>What is the name of the school that does not include the Mahayava scriptures in its canon?</query>\n\n"
-            "Example 3:\n"
-            "Question: Who was picked in the NBA draft before the player with the highest point average among active players?\n"
-            "Confirmed Passage 1: \"Wilt Chamberlain holds the all-time records for total points scored (4,029) and points per game (50.4) in a season; he also holds the rookie record when he averaged 37.6 points in the 1959–60 season. Among active players, Kevin Durant has the highest point average (32.0) in a season, achieved in the 2013–14 season.\"\n"
-            "Your Response: The question seeks to know who was picked in the NBA draft before the player with the highest point average among active players. The confirmed passage shows that Kevin Durant is that player but does not specify who was drafted before him. <query>Who was picked in the NBA draft before Kevin Durant?</query>\n\n"
-            "Example 4:\n"
-            "Question: When did the city that WIZE is licensed to broadcast to become the capital of the state that contains the county where the Battle of Rich Mountain occurred?\n"
-            "Confirmed Passage 1: \"The Battle of Rich Mountain took place on July 11, 1861, in Randolph County, Virginia (now West Virginia) during the American Civil War.\"\n"
-            "Confirmed Passage 2: \"Kaskaskia, located in that county, was Illinois's first capital.\"\n"
-            "Confirmed Passage 3: \"WIZE (1340 AM) is a radio station based in Springfield, Ohio.\"\n"
-            "Your Response: The confirmed passages provide historical context and indicate that Kaskaskia was Illinois's first capital, but they do not specify when Springfield became the capital of Illinois. <query>When did Springfield become the capital of Illinois?</query>\n\n"
-            "Example 5 (2-Hop with Two Confirmed Passages – <stop> Output):\n"
-            "Question: What river flows through Paris, and which iconic monument on its banks was completed in 1889?\n"
-            "Confirmed Passage 1: \"The Seine River flows through the heart of Paris.\"\n"
-            "Confirmed Passage 2: \"The Eiffel Tower, an iconic monument along the Seine, was completed in 1889.\"\n"
-            "Your Response: The question asks for the river flowing through Paris and the iconic monument completed in 1889 on its banks. The confirmed passages provide both details: the Seine River and the Eiffel Tower. All required information is present. <stop>\n\n"
-            "<|eot_id|>\n"
-            "<|start_header_id|>user<|end_header_id|>\n"
-            f"Question: {question}\n"
-        )
+        prompt = COT_WO_VERIFIER_PROMPT + question + "\n"
         if confirmed_passages:
             for idx, passage in enumerate(confirmed_passages, start=1):
                 prompt += f"Confirmed Passage {idx}: {passage['text']}\n"
@@ -82,20 +39,10 @@ class QueryGenerator:
             self._gen_retriever_query_prompt(question["question"], confirmed_passages)
             for question, confirmed_passages in zip(questions, batch_confirmed_passages)
         ]
-        inputs = self.tokenizer(prompts, padding=True, padding_side="left", return_tensors="pt").to(self.model.device)
 
-        input_lengths = [i.size(0) for i in inputs["input_ids"]]
-        outputs = self.model.generate(
-            **inputs,
-            max_new_tokens=self.max_gen_length,
-            temperature=self.temperature,
-            top_p=self.top_p,
-        )
-        generated_texts = self.tokenizer.batch_decode(
-            [output[input_lengths[i]:] for i, output in enumerate(outputs)],
-            skip_special_tokens=True,
-        )
-        clean_texts = [self.extract_query(text) for text in generated_texts]
+        outputs = self.llm.generate(prompts, self.sampling_params)
+
+        clean_texts = [self.extract_query(output.outputs[0].text) for output in outputs]
         return clean_texts
 
     def extract_query(self, generated_text):
@@ -110,18 +57,12 @@ class QueryGenerator:
         return generated_text.strip()
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--cache-dir", type=str, help="Cache directory for model")
-    args = parser.parse_args()
-    return args
-
-
-def test(args: argparse.Namespace):
+def test():
     query_generator = QueryGenerator(
-        model_id="meta-llama/Meta-Llama-3-8B-Instruct",
-        cache_dir=args.cache_dir,
-        max_gen_length=200,
+        model_id="casperhansen/llama-3.3-70b-instruct-awq",
+        tp_size=2,
+        quantization="awq_marlin",
+        max_gen_length=2048,
         temperature=0.7,
         top_p=0.9,
     )
@@ -143,5 +84,4 @@ def test(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    test(args)
+    test()

--- a/Training/verifier-train.py
+++ b/Training/verifier-train.py
@@ -353,6 +353,8 @@ def main():
         report_to=["wandb"],
         run_name=args.run_name,
         load_best_model_at_end=True,
+        metric_for_best_model="pairwise_accuracy",
+        greater_is_better=True, 
         ddp_find_unused_parameters=False,
         fp16=args.fp16,
     )

--- a/environment.yaml
+++ b/environment.yaml
@@ -26,3 +26,6 @@ dependencies:
       - wandb
       - peft
       - accelerate
+      - vllm
+      - autoawq
+      - autoawq-kernels


### PR DESCRIPTION
### 주요 변경사항
- inference는 전부 vLLM 이용
- Self-Ask 스타일 프롬프팅 적용 (`query_generator_self_ask.py`, `pipeline_self_ask.py`, `pipeline_self_ask_wo_verifier.py`)
- 파이프라인에서 verifier 이용 시 `fp16`, `device_map="auto"` 추가 (70B 모델이랑 같이 GPU에 올라가면 OOM 발생함)

스크립트는 아래와 같이 이용하고 있습니다 (torchrun 필요 X)
```shell
# 8B 모델 (default) 이용 시
python3 -m Full-Pipeline.pipeline_self_ask \
    --passages [path] \
    --embeddings [path] \
    --questions [path] \
    --verifier-checkpoint-path [path] \
    --verifier-threshold 0.85 \
    --stop-log-path [path]

# 70B 모델 (+ 4-bit quant) 이용 시
python3 -m Full-Pipeline.pipeline_self_ask \
    --passages [path] \
    --embeddings [path] \
    --questions [path] \
    --qg-model-id casperhansen/llama-3.3-70b-instruct-awq \
    --qg-tp-size 2 \
    --qg-quantization awq_marlin \
    --verifier-checkpoint-path [path] \
    --verifier-threshold 0.85 \
    --stop-log-path [path]
```

### 기타 수정사항
- model_id도 args로 받도록 수정
- pipeline에서 중간 결과 print할 때 각 batch의 결과가 아닌 그때까지의 누적 결과 반환하도록 수정 (`print_results()`의 호출 위치 변경)
- 프롬프트는 `prompts.py`에서 따로 관리하도록 수정